### PR TITLE
Display the repository hostname in filter

### DIFF
--- a/src/ClientApp/src/components/Filter.js
+++ b/src/ClientApp/src/components/Filter.js
@@ -170,7 +170,7 @@ export function Filter(props) {
               )}
             />
           }
-          label={repositoryTree.name}
+          label={new URL(repositoryTree.uri).hostname}
         />
       </FormGroup>
       {Array.isArray(repositoryTree.subsidiarySites)


### PR DESCRIPTION
Fixes: https://github.com/GeoWerkstatt/interlis-model-browser/issues/117