### PR TITLE
Remove unnecessary EnsureDeleted() statement

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -85,7 +85,6 @@ app.MapFallbackToFile("index.html");
 using (var scope = app.Services.CreateScope())
 {
     var context = scope.ServiceProvider.GetRequiredService<RepoBrowserContext>();
-    context.Database.EnsureDeleted();
     context.Database.EnsureCreated();
 }
 


### PR DESCRIPTION
The user has not enough rights to drop the db. The use of db migrations should be considered.