### PR TITLE
Extract just the preferred language from Request Header

### DIFF
--- a/src/Controllers/SearchController.cs
+++ b/src/Controllers/SearchController.cs
@@ -63,7 +63,9 @@ public class SearchController : ControllerBase
             {
                 Query = trimmedQuery,
                 SearchedAt = DateTime.UtcNow,
-                Language = Request?.Headers.AcceptLanguage.FirstOrDefault(),
+                Language = Request?.GetTypedHeaders().AcceptLanguage
+                    .OrderByDescending(l => l.Quality ?? 1.0)
+                    .FirstOrDefault()?.Value.Value,
             });
             context.SaveChanges();
         }


### PR DESCRIPTION
- Instead of `xx-XX;q=0.9.....` it now stores only the most preferred language of the browser, and only the language string (which usually looks like `xx-XX`. For german with swiss grammar, it's `de-CH`). Should make querying the DB easier.